### PR TITLE
Add gitignore coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 .env.test.local
 .env.production.local
 
+# jest
+/coverage


### PR DESCRIPTION
This is needed by the release CI to avoid including the coverage report in the versionbump commit (git add -A)