### PR TITLE
Fix Jest config

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * Ant
  */
 
 import type { Config } from 'jest';

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,6 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * Ant
  */
 
 import type { Config } from 'jest';
@@ -14,10 +13,8 @@ const config: Config = {
         '^.+\\.svg\\?react$': '<rootDir>/src/_mocks_/svg.tsx',
         '^.+\\.(css|less|scss)$': 'identity-obj-proxy',
     },
-    transformIgnorePatterns: [
-        'node_modules/(?!@gridsuite/commons-ui|react-dnd|dnd-core|@react-dnd|react-resizable-panels|uuid)',
-    ], // transform from ESM
-    moduleDirectories: ['node_modules', 'src'], // to allow absolute path from ./src
+    // see https://github.com/react-dnd/react-dnd/issues/3443
+    transformIgnorePatterns: ['node_modules/(?!react-dnd)/'],
     globals: {
         IS_REACT_ACT_ENVIRONMENT: true,
     },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,10 +16,6 @@ const config: Config = {
     transformIgnorePatterns: [
         'node_modules/(?!@gridsuite/commons-ui|react-dnd|dnd-core|@react-dnd|react-resizable-panels|uuid)',
     ], // transform from ESM
-    moduleDirectories: ['node_modules', 'src'], // to allow absolute path from ./src
-    globals: {
-        IS_REACT_ACT_ENVIRONMENT: true,
-    },
     setupFiles: ['<rootDir>/jest.setup.ts'],
 };
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,7 +14,7 @@ const config: Config = {
         '^.+\\.(css|less|scss)$': 'identity-obj-proxy',
     },
     transformIgnorePatterns: [
-        'node_modules/(?!@gridsuite/commons-ui|react-dnd|dnd-core|@react-dnd|react-resizable-panels|uuid)',
+        'node_modules/(?!react-dnd|dnd-core|@react-dnd|react-resizable-panels|uuid)',
     ], // transform from ESM
     setupFiles: ['<rootDir>/jest.setup.ts'],
 };

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -13,8 +13,10 @@ const config: Config = {
         '^.+\\.svg\\?react$': '<rootDir>/src/_mocks_/svg.tsx',
         '^.+\\.(css|less|scss)$': 'identity-obj-proxy',
     },
-    // see https://github.com/react-dnd/react-dnd/issues/3443
-    transformIgnorePatterns: ['node_modules/(?!react-dnd)/'],
+    transformIgnorePatterns: [
+        'node_modules/(?!@gridsuite/commons-ui|react-dnd|dnd-core|@react-dnd|react-resizable-panels|uuid)',
+    ], // transform from ESM
+    moduleDirectories: ['node_modules', 'src'], // to allow absolute path from ./src
     globals: {
         IS_REACT_ACT_ENVIRONMENT: true,
     },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,7 +14,7 @@ const config: Config = {
         '^.+\\.(css|less|scss)$': 'identity-obj-proxy',
     },
     transformIgnorePatterns: [
-        'node_modules/(?!@gridsuite/commons-ui|react-dnd|dnd-core|@react-dnd|uuid)',
+        'node_modules/(?!@gridsuite/commons-ui|react-dnd|dnd-core|@react-dnd|react-resizable-panels|uuid)',
     ], // transform from ESM
     moduleDirectories: ['node_modules', 'src'], // to allow absolute path from ./src
     globals: {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,8 +14,12 @@ const config: Config = {
         '^.+\\.(css|less|scss)$': 'identity-obj-proxy',
     },
     transformIgnorePatterns: [
-        'node_modules/(?!react-dnd|dnd-core|@react-dnd|react-resizable-panels|uuid)',
+        'node_modules/(?!@gridsuite/commons-ui|react-dnd|dnd-core|@react-dnd|react-resizable-panels|uuid)',
     ], // transform from ESM
+    moduleDirectories: ['node_modules', 'src'], // to allow absolute path from ./src
+    globals: {
+        IS_REACT_ACT_ENVIRONMENT: true,
+    },
     setupFiles: ['<rootDir>/jest.setup.ts'],
 };
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,8 +14,13 @@ const config: Config = {
         '^.+\\.svg\\?react$': '<rootDir>/src/_mocks_/svg.tsx',
         '^.+\\.(css|less|scss)$': 'identity-obj-proxy',
     },
-    // see https://github.com/react-dnd/react-dnd/issues/3443
-    transformIgnorePatterns: ['node_modules/(?!react-dnd)/'],
+    transformIgnorePatterns: [
+        'node_modules/(?!@gridsuite/commons-ui|react-dnd|dnd-core|@react-dnd|react-resizable-panels|uuid)',
+    ], // transform from ESM
+    moduleDirectories: ['node_modules', 'src'], // to allow absolute path from ./src
+    globals: {
+        IS_REACT_ACT_ENVIRONMENT: true,
+    },
     setupFiles: ['<rootDir>/jest.setup.ts'],
 };
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,7 +14,7 @@ const config: Config = {
         '^.+\\.(css|less|scss)$': 'identity-obj-proxy',
     },
     transformIgnorePatterns: [
-        'node_modules/(?!@gridsuite/commons-ui|react-dnd|dnd-core|@react-dnd|react-resizable-panels|uuid)',
+        'node_modules/(?!@gridsuite/commons-ui|react-dnd|dnd-core|@react-dnd|uuid)',
     ], // transform from ESM
     moduleDirectories: ['node_modules', 'src'], // to allow absolute path from ./src
     globals: {


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
On main, tests for gridadmin takes 3 minutes to run. 
Using the config from gridexplore, it takes 15s.     
It's a regression from https://github.com/gridsuite/gridadmin-app/pull/34/changes#diff-860bd1f15d1e0bafcfc6f62560524f588e6d6bf56d4ab1b0f6f8146461558730L16-R17
The problem is that all node modules are scanned due to the regexp evaluating to "//". Transforming all node_modules masked the necessary addition of commons-ui and other packages.
