### PR TITLE
feat(error-handling): generalize snack error with fallback

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -20,6 +20,7 @@ import {
     NotificationsUrlKeys,
     PARAM_LANGUAGE,
     PARAM_THEME,
+    snackWithFallback,
     useNotificationsListener,
     UserManagerState,
     useSnackMessage,
@@ -72,7 +73,7 @@ export default function App() {
             if (eventData?.headers?.parameterName) {
                 fetchConfigParameter(APP_NAME, eventData.headers.parameterName)
                     .then((param) => updateParams([param]))
-                    .catch((error) => snackError({ messageTxt: error.message, headerId: 'paramsRetrievingError' }));
+                    .catch((error) => snackWithFallback(snackError, error, { headerId: 'paramsRetrievingError' }));
             }
         },
         [updateParams, snackError]
@@ -84,21 +85,11 @@ export default function App() {
         if (user !== null) {
             fetchConfigParameters(COMMON_APP_NAME)
                 .then((params) => updateParams(params))
-                .catch((error) =>
-                    snackError({
-                        messageTxt: error.message,
-                        headerId: 'paramsRetrievingError',
-                    })
-                );
+                .catch((error) => snackWithFallback(snackError, error, { headerId: 'paramsRetrievingError' }));
 
             fetchConfigParameters(APP_NAME)
                 .then((params) => updateParams(params))
-                .catch((error) =>
-                    snackError({
-                        messageTxt: error.message,
-                        headerId: 'paramsRetrievingError',
-                    })
-                );
+                .catch((error) => snackWithFallback(snackError, error, { headerId: 'paramsRetrievingError' }));
         }
     }, [user, dispatch, updateParams, snackError]);
 

--- a/src/components/Grid/GridTable.tsx
+++ b/src/components/Grid/GridTable.tsx
@@ -23,7 +23,7 @@ import { Delete } from '@mui/icons-material';
 import { AgGrid, AgGridRef } from './AgGrid';
 import { GridOptions } from 'ag-grid-community';
 import { useIntl } from 'react-intl';
-import { useSnackMessage } from '@gridsuite/commons-ui';
+import { snackWithFallback, useSnackMessage } from '@gridsuite/commons-ui';
 
 type GridTableExposed = {
     refresh: () => Promise<void>;
@@ -67,10 +67,7 @@ export const GridTable: GridTableWithRef = forwardRef(function AgGridToolbar<TDa
     const loadDataAndSave = useCallback(
         function loadDataAndSave(): Promise<void> {
             return dataLoader().then(setData, (error) => {
-                snackError({
-                    messageTxt: error.message,
-                    headerId: 'table.error.retrieve',
-                });
+                snackWithFallback(snackError, error, { headerId: 'table.error.retrieve' });
             });
         },
         [dataLoader, snackError]

--- a/src/components/parameters.tsx
+++ b/src/components/parameters.tsx
@@ -7,7 +7,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { updateConfigParameter, useSnackMessage } from '@gridsuite/commons-ui';
+import { snackWithFallback, updateConfigParameter, useSnackMessage } from '@gridsuite/commons-ui';
 import { AppState, AppStateKey } from '../redux/reducer';
 import { APP_NAME } from '../utils/config-params';
 
@@ -26,10 +26,7 @@ export function useParameterState<K extends AppStateKey>(paramName: K): [AppStat
             updateConfigParameter(APP_NAME, paramName, value as string) //TODO how to check/cast?
                 .catch((error) => {
                     setParamLocalState(paramGlobalState);
-                    snackError({
-                        messageTxt: error.message,
-                        headerId: 'paramsChangingError',
-                    });
+                    snackWithFallback(snackError, error, { headerId: 'paramsChangingError' });
                 });
         },
         [paramName, snackError, setParamLocalState, paramGlobalState]

--- a/src/pages/announcements/add-announcement-form.tsx
+++ b/src/pages/announcements/add-announcement-form.tsx
@@ -22,7 +22,6 @@ import {
 } from 'react-hook-form-mui';
 import { DateTimePickerElement, type DateTimePickerElementProps } from 'react-hook-form-mui/date-pickers';
 import { UserAdminSrv } from '../../services';
-import { getErrorMessage, handleAnnouncementCreationErrors } from '../../utils/error';
 
 export const MESSAGE = 'message';
 export const START_DATE = 'startDate';
@@ -112,12 +111,9 @@ export default function AddAnnouncementForm({ onAnnouncementCreated }: Readonly<
             })
                 .then(() => onAnnouncementCreated?.())
                 .catch((error) => {
-                    let errorMessage = getErrorMessage(error) ?? '';
-                    if (!handleAnnouncementCreationErrors(errorMessage, snackError)) {
-                        snackWithFallback(snackError, error, {
-                            headerId: 'announcements.form.errCreateAnnouncement',
-                        });
-                    }
+                    snackWithFallback(snackError, error, {
+                        headerId: 'announcements.form.errCreateAnnouncement',
+                    });
                 });
         },
         [onAnnouncementCreated, snackError]

--- a/src/pages/announcements/add-announcement-form.tsx
+++ b/src/pages/announcements/add-announcement-form.tsx
@@ -9,7 +9,7 @@ import { useCallback, useMemo } from 'react';
 import { Grid } from '@mui/material';
 import { type DateOrTimeView } from '@mui/x-date-pickers';
 import { useIntl } from 'react-intl';
-import { SubmitButton, useSnackMessage, yupConfig as yup } from '@gridsuite/commons-ui';
+import { snackWithFallback, SubmitButton, useSnackMessage, yupConfig as yup } from '@gridsuite/commons-ui';
 import { type InferType } from 'yup';
 import { type SubmitHandler, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -114,7 +114,9 @@ export default function AddAnnouncementForm({ onAnnouncementCreated }: Readonly<
                 .catch((error) => {
                     let errorMessage = getErrorMessage(error) ?? '';
                     if (!handleAnnouncementCreationErrors(errorMessage, snackError)) {
-                        snackError({ headerId: 'announcements.form.errCreateAnnouncement', messageTxt: errorMessage });
+                        snackWithFallback(snackError, error, {
+                            headerId: 'announcements.form.errCreateAnnouncement',
+                        });
                     }
                 });
         },

--- a/src/pages/announcements/announcements-page.tsx
+++ b/src/pages/announcements/announcements-page.tsx
@@ -9,14 +9,13 @@ import type { UUID } from 'node:crypto';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Divider, Grid, Typography } from '@mui/material';
-import { useSnackMessage } from '@gridsuite/commons-ui';
+import { snackWithFallback, useSnackMessage } from '@gridsuite/commons-ui';
 import type { ColDef, GetRowIdParams, ValueFormatterFunc } from 'ag-grid-community';
 import { type GridTableRef } from '../../components/Grid';
 import { Announcement, UserAdminSrv } from '../../services';
 import AddAnnouncementForm from './add-announcement-form';
 import AgGrid from '../../components/Grid/AgGrid';
 import CancelCellRenderer from './cancel-cell-renderer';
-import { getErrorMessage } from '../../utils/error';
 
 const defaultColDef: ColDef<Announcement> = {
     editable: false,
@@ -43,7 +42,7 @@ export default function AnnouncementsPage() {
         try {
             setData(await UserAdminSrv.fetchAnnouncementList());
         } catch (error) {
-            snackError({ messageTxt: getErrorMessage(error) ?? undefined, headerId: 'table.error.retrieve' });
+            snackWithFallback(snackError, error, { headerId: 'table.error.retrieve' });
         }
     }, [snackError]);
 

--- a/src/pages/groups/add-group-dialog.tsx
+++ b/src/pages/groups/add-group-dialog.tsx
@@ -20,7 +20,7 @@ import { FormattedMessage } from 'react-intl';
 import { Controller, useForm } from 'react-hook-form';
 import { Groups } from '@mui/icons-material';
 import { GroupInfos, UserAdminSrv } from '../../services';
-import { useSnackMessage } from '@gridsuite/commons-ui';
+import { snackWithFallback, useSnackMessage } from '@gridsuite/commons-ui';
 import { GridTableRef } from '../../components/Grid';
 import PaperForm from '../common/paper-form';
 
@@ -36,8 +36,8 @@ const AddGroupDialog: FunctionComponent<AddGroupDialogProps> = (props) => {
     const addGroup = useCallback(
         (group: string) => {
             UserAdminSrv.addGroup(group)
-                .catch((_error) =>
-                    snackError({
+                .catch((error) =>
+                    snackWithFallback(snackError, error, {
                         headerId: 'groups.table.error.add',
                         headerValues: {
                             group: group,

--- a/src/pages/groups/groups-table.tsx
+++ b/src/pages/groups/groups-table.tsx
@@ -11,7 +11,7 @@ import { GroupAdd } from '@mui/icons-material';
 import { GridButton, GridButtonDelete, GridTable, GridTableRef } from '../../components/Grid';
 import { GroupInfos, UserAdminSrv, UserInfos } from '../../services';
 import { ColDef, GetRowIdParams, RowClickedEvent, TextFilterParams } from 'ag-grid-community';
-import { useSnackMessage } from '@gridsuite/commons-ui';
+import { snackWithFallback, useSnackMessage } from '@gridsuite/commons-ui';
 import { useCsvExport } from '../common/use-csv-export';
 import DeleteConfirmationDialog from '../common/delete-confirmation-dialog';
 import { defaultColDef, defaultRowSelection } from '../common/table-config';
@@ -49,10 +49,7 @@ const GroupsTable: FunctionComponent<GroupsTableProps> = (props) => {
                         headerId: 'groups.table.integrity.error.delete',
                     });
                 } else {
-                    snackError({
-                        messageTxt: error.message,
-                        headerId: 'groups.table.error.delete',
-                    });
+                    snackWithFallback(snackError, error, { headerId: 'groups.table.error.delete' });
                 }
             })
             .then(() => props.gridRef?.current?.context?.refresh?.());

--- a/src/pages/groups/modification/group-modification-dialog.tsx
+++ b/src/pages/groups/modification/group-modification-dialog.tsx
@@ -15,7 +15,7 @@ import GroupModificationForm, {
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm } from 'react-hook-form';
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
-import { CustomMuiDialog, FetchStatus, useSnackMessage } from '@gridsuite/commons-ui';
+import { CustomMuiDialog, FetchStatus, snackWithFallback, useSnackMessage } from '@gridsuite/commons-ui';
 import { formatFullName, GroupInfos, UserAdminSrv, UserInfos } from '../../../services';
 
 interface GroupModificationDialogProps {
@@ -67,10 +67,7 @@ const GroupModificationDialog: FunctionComponent<GroupModificationDialogProps> =
                 })
                 .catch((error) => {
                     setDataFetchStatus(FetchStatus.FETCH_ERROR);
-                    snackError({
-                        messageTxt: error.message,
-                        headerId: 'groups.table.error.users',
-                    });
+                    snackWithFallback(snackError, error, { headerId: 'groups.table.error.users' });
                 });
         }
     }, [open, snackError, groupInfos, reset]);
@@ -100,12 +97,7 @@ const GroupModificationDialog: FunctionComponent<GroupModificationDialogProps> =
                     users: selectedUsers,
                 };
                 UserAdminSrv.udpateGroup(newData)
-                    .catch((error) =>
-                        snackError({
-                            messageTxt: error.message,
-                            headerId: 'groups.table.error.update',
-                        })
-                    )
+                    .catch((error) => snackWithFallback(snackError, error, { headerId: 'groups.table.error.update' }))
                     .then(() => {
                         onUpdate();
                     });

--- a/src/pages/profiles/add-profile-dialog.tsx
+++ b/src/pages/profiles/add-profile-dialog.tsx
@@ -20,7 +20,7 @@ import { FormattedMessage } from 'react-intl';
 import { Controller, useForm } from 'react-hook-form';
 import { ManageAccounts } from '@mui/icons-material';
 import { UserAdminSrv, UserProfile } from '../../services';
-import { useSnackMessage } from '@gridsuite/commons-ui';
+import { snackWithFallback, useSnackMessage } from '@gridsuite/commons-ui';
 import { GridTableRef } from '../../components/Grid';
 import PaperForm from '../common/paper-form';
 
@@ -45,8 +45,8 @@ const AddProfileDialog: FunctionComponent<AddProfileDialogProps> = (props) => {
                 name: name,
             };
             UserAdminSrv.addProfile(profileData)
-                .catch((_error) =>
-                    snackError({
+                .catch((error) =>
+                    snackWithFallback(snackError, error, {
                         headerId: 'profiles.table.error.add',
                         headerValues: {
                             profile: profileData.name,

--- a/src/pages/profiles/modification/profile-modification-dialog.tsx
+++ b/src/pages/profiles/modification/profile-modification-dialog.tsx
@@ -22,7 +22,13 @@ import ProfileModificationForm, {
 import { yupResolver } from '@hookform/resolvers/yup';
 import { type SubmitHandler, useForm } from 'react-hook-form';
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
-import { CustomMuiDialog, FetchStatus, useSnackMessage, yupConfig as yup } from '@gridsuite/commons-ui';
+import {
+    CustomMuiDialog,
+    FetchStatus,
+    snackWithFallback,
+    useSnackMessage,
+    yupConfig as yup,
+} from '@gridsuite/commons-ui';
 import { UserAdminSrv, UserProfile } from '../../../services';
 import type { UUID } from 'node:crypto';
 import { InferType } from 'yup';
@@ -89,10 +95,7 @@ const ProfileModificationDialog: FunctionComponent<ProfileModificationDialogProp
                 };
                 UserAdminSrv.modifyProfile(profileData)
                     .catch((error) => {
-                        snackError({
-                            messageTxt: error.message,
-                            headerId: 'profiles.form.modification.updateError',
-                        });
+                        snackWithFallback(snackError, error, { headerId: 'profiles.form.modification.updateError' });
                     })
                     .then(() => {
                         onUpdate();
@@ -130,10 +133,7 @@ const ProfileModificationDialog: FunctionComponent<ProfileModificationDialogProp
                 })
                 .catch((error) => {
                     setDataFetchStatus(FetchStatus.FETCH_ERROR);
-                    snackError({
-                        messageTxt: error.message,
-                        headerId: 'profiles.form.modification.readError',
-                    });
+                    snackWithFallback(snackError, error, { headerId: 'profiles.form.modification.readError' });
                 });
         }
     }, [profileId, open, reset, snackError]);

--- a/src/pages/profiles/profiles-table.tsx
+++ b/src/pages/profiles/profiles-table.tsx
@@ -11,7 +11,7 @@ import { ManageAccounts } from '@mui/icons-material';
 import { GridButton, GridButtonDelete, GridTable, GridTableRef } from '../../components/Grid';
 import { UserAdminSrv, UserProfile } from '../../services';
 import { ColDef, GetRowIdParams, ITooltipParams, RowClickedEvent, TextFilterParams } from 'ag-grid-community';
-import { useSnackMessage } from '@gridsuite/commons-ui';
+import { snackWithFallback, useSnackMessage } from '@gridsuite/commons-ui';
 import DeleteConfirmationDialog from '../common/delete-confirmation-dialog';
 import { defaultColDef, defaultRowSelection } from '../common/table-config';
 import ValidityCellRenderer from './validity-cell-renderer';
@@ -45,10 +45,7 @@ const ProfilesTable: FunctionComponent<ProfilesTableProps> = (props) => {
                         headerId: 'profiles.table.integrity.error.delete',
                     });
                 } else {
-                    snackError({
-                        messageTxt: error.message,
-                        headerId: 'profiles.table.error.delete',
-                    });
+                    snackWithFallback(snackError, error, { headerId: 'profiles.table.error.delete' });
                 }
             })
             .then(() => props.gridRef?.current?.context?.refresh?.());

--- a/src/pages/users/add-user-dialog.tsx
+++ b/src/pages/users/add-user-dialog.tsx
@@ -20,7 +20,7 @@ import { FormattedMessage } from 'react-intl';
 import { Controller, useForm } from 'react-hook-form';
 import { AccountCircle } from '@mui/icons-material';
 import { UserAdminSrv, UserInfos } from '../../services';
-import { useSnackMessage } from '@gridsuite/commons-ui';
+import { snackWithFallback, useSnackMessage } from '@gridsuite/commons-ui';
 import { GridTableRef } from '../../components/Grid';
 import PaperForm from '../common/paper-form';
 
@@ -42,8 +42,8 @@ const AddUserDialog: FunctionComponent<AddUserDialogProps> = (props) => {
     const addUser = useCallback(
         (id: string) => {
             UserAdminSrv.addUser(id)
-                .catch((_error) =>
-                    snackError({
+                .catch((error) =>
+                    snackWithFallback(snackError, error, {
                         headerId: 'users.table.error.add',
                         headerValues: {
                             user: id,

--- a/src/pages/users/modification/user-modification-dialog.tsx
+++ b/src/pages/users/modification/user-modification-dialog.tsx
@@ -17,7 +17,7 @@ import UserModificationForm, {
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm } from 'react-hook-form';
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
-import { CustomMuiDialog, FetchStatus, useSnackMessage } from '@gridsuite/commons-ui';
+import { CustomMuiDialog, FetchStatus, snackWithFallback, useSnackMessage } from '@gridsuite/commons-ui';
 import { formatFullName, GroupInfos, UserAdminSrv, UserInfos, UserProfile } from '../../../services';
 
 interface UserModificationDialogProps {
@@ -67,10 +67,7 @@ const UserModificationDialog: FunctionComponent<UserModificationDialogProps> = (
                     );
                 })
                 .catch((error) => {
-                    snackError({
-                        messageTxt: error.message,
-                        headerId: 'users.table.error.profiles',
-                    });
+                    snackWithFallback(snackError, error, { headerId: 'users.table.error.profiles' });
                 });
 
             groupPromise
@@ -82,10 +79,7 @@ const UserModificationDialog: FunctionComponent<UserModificationDialogProps> = (
                     );
                 })
                 .catch((error) => {
-                    snackError({
-                        messageTxt: error.message,
-                        headerId: 'users.table.error.groups',
-                    });
+                    snackWithFallback(snackError, error, { headerId: 'users.table.error.groups' });
                 });
 
             Promise.all([profilePromise, groupPromise])
@@ -122,7 +116,7 @@ const UserModificationDialog: FunctionComponent<UserModificationDialogProps> = (
                     profileName: userFormData.profileName ?? undefined,
                     groups: selectedGroups,
                 })
-                    .catch((error) => snackError({ messageTxt: error.message, headerId: 'users.table.error.update' }))
+                    .catch((error) => snackWithFallback(snackError, error, { headerId: 'users.table.error.update' }))
                     .then(() => onUpdate());
             }
         },

--- a/src/pages/users/users-table.tsx
+++ b/src/pages/users/users-table.tsx
@@ -11,7 +11,7 @@ import { PersonAdd } from '@mui/icons-material';
 import { GridButton, GridButtonDelete, GridTable, type GridTableRef } from '../../components/Grid';
 import { formatFullName, type GroupInfos, UserAdminSrv, type UserInfos } from '../../services';
 import type { ColDef, GetRowIdParams, RowClickedEvent, TextFilterParams } from 'ag-grid-community';
-import { useSnackMessage } from '@gridsuite/commons-ui';
+import { snackWithFallback, useSnackMessage } from '@gridsuite/commons-ui';
 import DeleteConfirmationDialog from '../common/delete-confirmation-dialog';
 import { defaultColDef, defaultRowSelection } from '../common/table-config';
 import MultiChipCellRenderer from '../common/multi-chip-cell-renderer';
@@ -43,12 +43,7 @@ const UsersTable: FunctionComponent<UsersTableProps> = (props) => {
     const deleteUsers = useCallback(() => {
         let subs = rowsSelection.map((user) => user.sub);
         return UserAdminSrv.deleteUsers(subs)
-            .catch((error) =>
-                snackError({
-                    messageTxt: error.message,
-                    headerId: 'users.table.error.delete',
-                })
-            )
+            .catch((error) => snackWithFallback(snackError, error, { headerId: 'users.table.error.delete' }))
             .then(() => props.gridRef?.current?.context?.refresh?.());
     }, [props.gridRef, rowsSelection, snackError]);
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -125,9 +125,6 @@
     "announcements.severity.WARN": "Warning",
     "announcements.form.message": "Announcement message",
     "announcements.form.errCreateAnnouncement": "Error while creating announcement:",
-    "announcements.form.errCreateAnnouncement.noOverlapAllowedErr": "The date overlaps with another announcement date.",
-    "announcements.form.errCreateAnnouncement.noSameDateErr": "The announcement start and end date must be different.",
-    "announcements.form.errCreateAnnouncement.startDateAfterEndDateErr": "The start date cannot be after the end date.",
     "announcements.form.errForm.startDateAfterEndDateErr": "End date must be after start date.",
     "announcements.form.errForm.msgMaxLength": "Message must be at most 200 characters.",
 

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -126,9 +126,6 @@
     "announcements.severity.WARN": "Avertissement",
     "announcements.form.message": "Message d'annonce",
     "announcements.form.errCreateAnnouncement": "Erreur lors de la création de l'annonce :",
-    "announcements.form.errCreateAnnouncement.noOverlapAllowedErr": "La date d'annonce chevauche une autre date d'annonce.",
-    "announcements.form.errCreateAnnouncement.noSameDateErr": "La date de début et de fin d'annonce doivent être différentes.",
-    "announcements.form.errCreateAnnouncement.startDateAfterEndDateErr": "La date de début d'annonce ne peut pas être après la date de fin.",
     "announcements.form.errForm.startDateAfterEndDateErr": "La date de fin doit être après la date de début.",
     "announcements.form.errForm.msgMaxLength": "Le message ne doit pas dépasser 200 caractères.",
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -24,30 +24,3 @@ export function getErrorMessage(error: unknown): string | null {
         return JSON.stringify(error ?? undefined) ?? null;
     }
 }
-
-const OVERLAPPING_ANNOUNCEMENTS = 'OVERLAPPING_ANNOUNCEMENTS';
-const SAME_START_END_DATE = 'SAME_START_END_DATE';
-const START_DATE_AFTER_END_DATE = 'START_DATE_AFTER_END_DATE';
-
-export function handleAnnouncementCreationErrors(error: string, snackError: Function): boolean {
-    if (error.includes(OVERLAPPING_ANNOUNCEMENTS)) {
-        snackError({
-            headerId: 'announcements.form.errCreateAnnouncement',
-            messageId: 'announcements.form.errCreateAnnouncement.noOverlapAllowedErr',
-        });
-        return true;
-    } else if (error.includes(SAME_START_END_DATE)) {
-        snackError({
-            headerId: 'announcements.form.errCreateAnnouncement',
-            messageId: 'announcements.form.errCreateAnnouncement.noSameDateErr',
-        });
-        return true;
-    } else if (error.includes(START_DATE_AFTER_END_DATE)) {
-        snackError({
-            headerId: 'announcements.form.errCreateAnnouncement',
-            messageId: 'announcements.form.errCreateAnnouncement.startDateAfterEndDateErr',
-        });
-        return true;
-    }
-    return false;
-}


### PR DESCRIPTION
## Summary
- Replace `snackError({ messageTxt: error.message, ... })` patterns with `snackWithFallback(snackError, error, { ... })` across the app so that structured errors raised by `backendFetch`/`backendFetchJson` are surfaced with their business code or technical details.
- Aligned with gridstudy migration (gridsuite/gridstudy-app#3452 and #3890).

## Notes
- For announcement errors, we use new server errors, more complete
<img width="1832" height="569" alt="image" src="https://github.com/user-attachments/assets/33ee080c-087c-4c45-817b-4694cfe51ed9" />
- In add dialogs (`add-user`/`add-group`/`add-profile`), the previously-ignored `_error` is now wired into `snackWithFallback` so server-side reasons reach the user.